### PR TITLE
Issue 188 use viewer multiple sources

### DIFF
--- a/apps/publisher/src/app.tsx
+++ b/apps/publisher/src/app.tsx
@@ -163,6 +163,10 @@ function App() {
       startStreamingSource({
         mediaStream: displayStream,
         sourceId: DisplayShareSourceId,
+        simulcast: isSimulcastEnabled,
+        codec,
+        events: ['viewercount'],
+        bandwidth: bitrate,
       });
   }, [displayStream, publisherState]);
 
@@ -280,6 +284,10 @@ function App() {
                       startStreamingSource({
                         mediaStream: displayStream,
                         sourceId: DisplayShareSourceId,
+                        simulcast: isSimulcastEnabled,
+                        codec,
+                        events: ['viewercount'],
+                        bandwidth: bitrate,
                       });
                     }
                   } catch (err) {

--- a/libs/use-viewer/src/index.ts
+++ b/libs/use-viewer/src/index.ts
@@ -39,6 +39,23 @@ const reducer = (sources: RemoteTrackSources, action: ViewerAction): RemoteTrack
       newSources.delete(action.sourceId);
       return newSources;
     }
+    case ViewerActionType.UPDATE_SOURCES_STATISTICS: {
+      const { audio, video } = action.statistics;
+      const newSources = new Map();
+      for (const [id, source] of sources) {
+        const sourceAudio = audio.filter(({ mid }) => mid === source.audioMediaId);
+        const sourceVideo = video.filter(({ mid }) => mid === source.videoMediaId);
+        const newSource = {
+          ...source,
+          statistics: {
+            audio: sourceAudio,
+            video: sourceVideo,
+          },
+        };
+        newSources.set(id, newSource);
+      }
+      return newSources;
+    }
     default:
       return sources;
   }
@@ -166,11 +183,11 @@ const useViewer = ({ streamName, streamAccountId, subscriberToken, handleError }
       console.log('register broadcastEvent');
       viewer.current?.webRTCPeer?.initStats();
       viewer.current?.webRTCPeer?.on('stats', (statistics: StreamStats) => {
-        // console.log('statistics event', statistics);
-        // const videoInbounds = statistics.video.inbounds.filter((stats) => stats.mid === mainVideoMidRef.current);
-        // if (videoInbounds) statistics.video.inbounds = videoInbounds;
-        // const audioInbounds = statistics.audio.inbounds.filter((stats) => stats.mid === mainAudioMidRef.current);
-        // if (audioInbounds) statistics.audio.inbounds = audioInbounds;
+        dispatch({
+          statistics: { audio: statistics.audio.inbounds, video: statistics.video.inbounds },
+          type: ViewerActionType.UPDATE_SOURCES_STATISTICS,
+          viewer: viewer.current as View,
+        });
       });
     }
   };

--- a/libs/use-viewer/src/types.ts
+++ b/libs/use-viewer/src/types.ts
@@ -1,9 +1,10 @@
-import { LayerInfo, StreamAudioInboundsStats, StreamVideoInboundsStats, View } from '@millicast/sdk';
+import { LayerInfo, Media, StreamAudioInboundsStats, StreamVideoInboundsStats, View } from '@millicast/sdk';
 
 export enum ViewerActionType {
   ADD_SOURCE = 'ADD_SOURCE',
   REMOVE_SOURCE = 'REMOVE_SOURCE',
   UPDATE_SOURCES_STATISTICS = 'UPDATE_SOURCES_STATISTICS',
+  UPDATE_SOURCES_QUALITIES = 'UPDATE_SOURCES_QUALITIES',
 }
 
 export type RemoteTrackSource = {
@@ -42,7 +43,8 @@ export type Viewer = {
 export type ViewerAction =
   | { source: RemoteTrackSource; type: ViewerActionType.ADD_SOURCE }
   | { sourceId: SourceId; type: ViewerActionType.REMOVE_SOURCE; viewer: View }
-  | { statistics: RemoteTrackSourceStatistics; type: ViewerActionType.UPDATE_SOURCES_STATISTICS; viewer: View };
+  | { statistics: RemoteTrackSourceStatistics; type: ViewerActionType.UPDATE_SOURCES_STATISTICS; viewer: View }
+  | { medias: Media[]; type: ViewerActionType.UPDATE_SOURCES_QUALITIES; viewer: View };
 
 export type ViewerProps = {
   handleError?: (error: string) => void;

--- a/libs/use-viewer/src/types.ts
+++ b/libs/use-viewer/src/types.ts
@@ -3,21 +3,24 @@ import { LayerInfo, StreamAudioInboundsStats, StreamVideoInboundsStats, View } f
 export enum ViewerActionType {
   ADD_SOURCE = 'ADD_SOURCE',
   REMOVE_SOURCE = 'REMOVE_SOURCE',
+  UPDATE_SOURCES_STATISTICS = 'UPDATE_SOURCES_STATISTICS',
 }
 
 export type RemoteTrackSource = {
   audioMediaId?: string;
   mediaStream: MediaStream;
   sourceId: SourceId;
-  statistics?: {
-    audio: StreamAudioInboundsStats[];
-    video: StreamVideoInboundsStats[];
-  };
+  statistics?: RemoteTrackSourceStatistics;
   streamQualityOptions: SimulcastQuality[];
   videoMediaId?: string;
 };
 
 export type RemoteTrackSources = Map<SourceId, RemoteTrackSource>;
+
+export type RemoteTrackSourceStatistics = {
+  audio: StreamAudioInboundsStats[];
+  video: StreamVideoInboundsStats[];
+};
 
 export type SimulcastQuality = {
   simulcastLayer?: LayerInfo; // Auto has an idx of null
@@ -38,7 +41,8 @@ export type Viewer = {
 
 export type ViewerAction =
   | { source: RemoteTrackSource; type: ViewerActionType.ADD_SOURCE }
-  | { sourceId: SourceId; type: ViewerActionType.REMOVE_SOURCE; viewer: View };
+  | { sourceId: SourceId; type: ViewerActionType.REMOVE_SOURCE; viewer: View }
+  | { statistics: RemoteTrackSourceStatistics; type: ViewerActionType.UPDATE_SOURCES_STATISTICS; viewer: View };
 
 export type ViewerProps = {
   handleError?: (error: string) => void;

--- a/libs/use-viewer/src/utils.ts
+++ b/libs/use-viewer/src/utils.ts
@@ -16,7 +16,6 @@ export const addRemoteTrackAndProject = async (
     statistics: { audio: [], video: [] },
     streamQualityOptions: [{ streamQuality: 'Auto' }],
   };
-  console.log({ trackInfos });
   let trackInfo = trackInfos.find((info) => info.media == 'video');
   if (trackInfo) {
     videoTransceiver = await viewer.addRemoteTrack('video', [mediaStream]);
@@ -29,7 +28,6 @@ export const addRemoteTrackAndProject = async (
   trackInfo = trackInfos.find((info) => info.media == 'audio');
   if (trackInfo) {
     audioTransceiver = await viewer.addRemoteTrack('audio', [mediaStream]);
-    console.log({ audioTransceiver });
     const audioMid = audioTransceiver?.mid ?? undefined;
     if (audioMid) {
       mapping.push({ trackId: trackInfo.trackId, mediaId: audioMid, media: trackInfo.media });
@@ -59,7 +57,6 @@ export const buildQualityOptions = (layers: MediaLayer[]) => {
     default:
       return [{ streamQuality: 'Auto' } as SimulcastQuality];
   }
-  console.log('buildQualityOptions');
   const qualityOptions: SimulcastQuality[] = layers.map((layer, idx) => ({
     simulcastLayer: {
       bitrate: layer.bitrate,

--- a/libs/use-viewer/src/utils.ts
+++ b/libs/use-viewer/src/utils.ts
@@ -13,6 +13,7 @@ export const addRemoteTrackAndProject = async (
   const trackSource: RemoteTrackSource = {
     mediaStream,
     sourceId,
+    statistics: { audio: [], video: [] },
     streamQualityOptions: [{ streamQuality: 'Auto' }],
   };
   console.log({ trackInfos });

--- a/libs/use-viewer/src/utils.ts
+++ b/libs/use-viewer/src/utils.ts
@@ -1,5 +1,5 @@
-import { MediaTrackInfo, View, ViewProjectSourceMapping } from '@millicast/sdk';
-import { RemoteTrackSource } from './types';
+import { MediaLayer, MediaTrackInfo, View, ViewProjectSourceMapping } from '@millicast/sdk';
+import { RemoteTrackSource, SimulcastQuality, StreamQuality } from './types';
 
 export const addRemoteTrackAndProject = async (
   sourceId: string,
@@ -45,6 +45,32 @@ export const addRemoteTrackAndProject = async (
   } catch (error: unknown) {
     return Promise.reject(error);
   }
+};
+
+export const buildQualityOptions = (layers: MediaLayer[]) => {
+  const qualities: StreamQuality[] = [];
+  switch (layers.length) {
+    case 2:
+      qualities.push('High', 'Low');
+      break;
+    case 3:
+      qualities.push('High', 'Medium', 'Low');
+      break;
+    default:
+      return [{ streamQuality: 'Auto' } as SimulcastQuality];
+  }
+  console.log('buildQualityOptions');
+  const qualityOptions: SimulcastQuality[] = layers.map((layer, idx) => ({
+    simulcastLayer: {
+      bitrate: layer.bitrate,
+      encodingId: layer.id,
+      simulcastIdx: layer.simulcastIdx,
+      spatialLayerId: layer.layers[0]?.spatialLayerId, // H264 doesn't have layers.
+      temporalLayerId: layer.layers[0]?.temporalLayerId, // H264 doesn't have layers.
+    },
+    streamQuality: qualities[idx],
+  }));
+  return qualityOptions;
 };
 
 export const unprojectAndRemoveRemoteTrack = async (source: RemoteTrackSource, viewer: View) => {


### PR DESCRIPTION
Issue: https://github.com/dolbyio-samples/rts-app-react-publisher-viewer/issues/188

### Description

Provide each source with statistics and quality options when there are multiple streams

### Changes

- Created statistics event handler in `useViewer` hook
- Created reducer to update per-source statistics in `useViewer` hook
- Enabled `layer` event for `viewer`
- Created reducer to update per-source layers (video quality) in `useViewer` hook