### PR TITLE
Issue 203 remove start stop button

### DIFF
--- a/apps/viewer/src/app.tsx
+++ b/apps/viewer/src/app.tsx
@@ -1,39 +1,12 @@
-import {
-  VStack,
-  Text,
-  HStack,
-  Flex,
-  Spacer,
-  Box,
-  Heading,
-  Popover,
-  PopoverBody,
-  PopoverCloseButton,
-  PopoverContent,
-  PopoverHeader,
-  PopoverTrigger,
-  Stack,
-  Button,
-} from '@chakra-ui/react';
+import { Box, Flex, HStack, Heading, Text, VStack } from '@chakra-ui/react';
 import React, { useEffect, useState } from 'react';
 import useNotification from '@millicast-react/use-notification';
-import useViewer, { SimulcastQuality, StreamQuality } from '@millicast-react/use-viewer';
-import {
-  IconProfile,
-  IconInfo,
-  IconSettings,
-  IconCameraOn,
-  IconCameraOff,
-  IconSpeaker,
-  IconSpeakerOff,
-} from '@millicast-react/dolbyio-icons';
+import useViewer from '@millicast-react/use-viewer';
+import { IconCameraOff, IconCameraOn, IconSpeaker, IconSpeakerOff } from '@millicast-react/dolbyio-icons';
 import VideoView from '@millicast-react/video-view';
 import ParticipantCount from '@millicast-react/participant-count';
 import Timer from '@millicast-react/timer';
-import IconButton from '@millicast-react/icon-button';
 import ActionBar from '@millicast-react/action-bar';
-import Dropdown from '@millicast-react/dropdown';
-import StatisticsInfo from '@millicast-react/statistics-info';
 import InfoLabel from '@millicast-react/info-label';
 import ControlBar from '@millicast-react/control-bar';
 import './styles/font.css';
@@ -103,8 +76,6 @@ function App() {
       setTrackSourcesStates(newTrackSourcesStates);
     }
   }, [remoteTrackSources]);
-
-  console.log('app log', remoteTrackSources, viewerCount);
 
   return (
     <Flex direction="column" minH="100vh" w="100vw" bg="background" p="6">

--- a/apps/viewer/src/app.tsx
+++ b/apps/viewer/src/app.tsx
@@ -84,6 +84,16 @@ function App() {
   // const [displayStreamMuted, setDisplayStreamMuted] = useState(true);
   // const [displayStreamDisplayVideo, setDisplayStreamDisplayVideo] = useState(true);
 
+  const isStreaming = remoteTrackSources.size > 0;
+  const hasMultiStream = remoteTrackSources.size > 1;
+
+  useEffect(() => {
+    startViewer();
+    return () => {
+      stopViewer();
+    };
+  }, []);
+
   useEffect(() => {
     const newTrackSourcesStates = new Map(trackSourcesStates);
     remoteTrackSources.forEach((source) => {
@@ -93,9 +103,6 @@ function App() {
       setTrackSourcesStates(newTrackSourcesStates);
     }
   }, [remoteTrackSources]);
-
-  const isStreaming = remoteTrackSources.size > 0;
-  const hasMultiStream = remoteTrackSources.size > 1;
 
   console.log('app log', remoteTrackSources, viewerCount);
 

--- a/apps/viewer/src/app.tsx
+++ b/apps/viewer/src/app.tsx
@@ -112,14 +112,6 @@ function App() {
         <ActionBar title="Company name" />
         <Flex w="100%" justifyContent="space-between" mt="4" position="relative" zIndex={1}>
           <VStack spacing="4" alignItems="flex-start">
-            <Button
-              onClick={() => {
-                isStreaming ? stopViewer() : startViewer();
-              }}
-            >
-              {' '}
-              Start/Stop{' '}
-            </Button>
             <Flex alignItems="center">
               <Timer isActive={isStreaming} />
               {hasMultiStream && (


### PR DESCRIPTION
Issue: https://github.com/dolbyio-samples/rts-app-react-publisher-viewer/issues/203

### Description
Remove the start/stop button in the viewer app. Automatically start the viewer upon load, instead of using the button. Although the related ticket is marked as a bug, this is not a defect and was a known feature change