### PR TITLE
Filter out VP9 when Simulcast is enabled

### DIFF
--- a/apps/publisher/src/app.tsx
+++ b/apps/publisher/src/app.tsx
@@ -176,7 +176,7 @@ function App() {
 
   const codecListSimulcast = useMemo(() => {
     if (isSimulcastEnabled) {
-      return codecList.filter((item) => item !== 'VP9');
+      return codecList.filter((item) => item.toLowerCase() !== 'vp9');
     }
     return codecList;
   }, [codecList, isSimulcastEnabled]);


### PR DESCRIPTION
This probably was an oversight somewhere - the correct way to compare was to make it case-insensitive or lowercase everything. 