### PR TITLE
Issue 205: Stream name must not change after page load

### DIFF
--- a/apps/publisher/src/app.tsx
+++ b/apps/publisher/src/app.tsx
@@ -63,10 +63,11 @@ const MainSourceId = 'Main';
 const DisplayShareSourceId = 'DisplayShare';
 type PublisherState = SourceState;
 
-function App() {
-  const date = new Date();
-  const [streamName, _] = useState(import.meta.env.VITE_MILLICAST_STREAM_NAME || date.valueOf().toString());
+const date = new Date();
+const streamName =
+  typeof window !== 'undefined' ? import.meta.env.VITE_MILLICAST_STREAM_NAME || date.valueOf().toString() : undefined;
 
+function App() {
   useEffect(() => {
     // prevent closing the page
     const pageCloseHandler = (event: BeforeUnloadEvent) => {

--- a/apps/publisher/src/app.tsx
+++ b/apps/publisher/src/app.tsx
@@ -64,6 +64,9 @@ const DisplayShareSourceId = 'DisplayShare';
 type PublisherState = SourceState;
 
 function App() {
+  const date = new Date();
+  const [streamName, _] = useState(import.meta.env.VITE_MILLICAST_STREAM_NAME || date.valueOf().toString());
+
   useEffect(() => {
     // prevent closing the page
     const pageCloseHandler = (event: BeforeUnloadEvent) => {
@@ -78,7 +81,6 @@ function App() {
   const { isOpen: isDrawerOpen, onOpen: onDrawerOpen, onClose: onDrawerClose } = useDisclosure();
   const { showError } = useNotification();
 
-  const date = new Date();
   const {
     startStreamingSource,
     stopStreamingSource,
@@ -92,7 +94,7 @@ function App() {
   } = usePublisher({
     token: import.meta.env.VITE_MILLICAST_STREAM_PUBLISHING_TOKEN,
     streamId: import.meta.env.VITE_MILLICAST_STREAM_ID,
-    streamName: import.meta.env.VITE_MILLICAST_STREAM_NAME || date.valueOf().toString(),
+    streamName: streamName,
     viewerAppBaseUrl: import.meta.env.VITE_MILLICAST_VIEWER_BASE_URL,
     handleError: showError,
   });
@@ -176,7 +178,7 @@ function App() {
 
   const codecListSimulcast = useMemo(() => {
     if (isSimulcastEnabled) {
-      return codecList.filter((item) => item.toLowerCase() !== 'vp9');
+      return codecList.filter((item) => item !== 'VP9');
     }
     return codecList;
   }, [codecList, isSimulcastEnabled]);


### PR DESCRIPTION
Closes #205 and #208


The stream name would change every time the go live button was pressed. Make it only generate once, that too on page load. 