### PR TITLE
fixed #205  Stream name in the invitation link always change

### DIFF
--- a/apps/publisher/src/app.tsx
+++ b/apps/publisher/src/app.tsx
@@ -63,6 +63,8 @@ const MainSourceId = 'Main';
 const DisplayShareSourceId = 'DisplayShare';
 type PublisherState = SourceState;
 
+const date = new Date();
+
 function App() {
   useEffect(() => {
     // prevent closing the page
@@ -78,7 +80,6 @@ function App() {
   const { isOpen: isDrawerOpen, onOpen: onDrawerOpen, onClose: onDrawerClose } = useDisclosure();
   const { showError } = useNotification();
 
-  const date = new Date();
   const {
     startStreamingSource,
     stopStreamingSource,


### PR DESCRIPTION
The stream name for the viewer app only changes when the user refreshes the page. It should keep the same value in all other conditions.