### PR TITLE
Issue 328 handle update quality options for main stream only

### DIFF
--- a/apps/viewer/src/app.tsx
+++ b/apps/viewer/src/app.tsx
@@ -1,5 +1,5 @@
 import { Box, Center, Flex, Heading, HStack, Text, VStack } from '@chakra-ui/react';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import ActionBar from '@millicast-react/action-bar';
 import { IconProfile } from '@millicast-react/dolbyio-icons';
@@ -25,6 +25,7 @@ const App = () => {
 
   const {
     mainMediaStream,
+    mainQualityOptions,
     mainStatistics,
     projectToMainStream,
     remoteTrackSources,
@@ -36,8 +37,6 @@ const App = () => {
   } = useViewer({ handleError: showError, streamAccountId, streamName });
 
   const [mainSourceId, setMainSourceId] = useState<string>();
-
-  const mainSource = mainSourceId !== undefined ? remoteTrackSources.get(mainSourceId) : undefined;
 
   // Prevent closing the page
   useEffect(() => {
@@ -71,52 +70,50 @@ const App = () => {
 
   // Reset main stream when layers change
   useEffect(() => {
-    if (!mainSource) {
+    if (!mainSourceId) {
       return;
     }
 
-    const { quality, sourceId, streamQualityOptions } = mainSource;
-    const streamQualities = streamQualityOptions.map(({ streamQuality }) => streamQuality);
+    const { quality } = remoteTrackSources.get(mainSourceId) ?? {};
+    const streamQualities = mainQualityOptions.map(({ streamQuality }) => streamQuality);
 
-    if (!quality || !streamQualities.includes(quality)) {
+    if (!quality || !streamQualities?.includes(quality)) {
       // Must reproject before resetting quality
-      projectToMainStream(sourceId).then(() => {
-        setSourceQuality(sourceId);
+      projectToMainStream(mainSourceId).then(() => {
+        setSourceQuality(mainSourceId);
       });
     }
-  }, [mainSource?.streamQualityOptions.length]);
+  }, [mainQualityOptions.length]);
 
-  const changeMainSource = async (sourceId: string) => {
-    const { sourceId: prevSourceId } = mainSource ?? {};
-
-    if (prevSourceId) {
-      reprojectFromMainStream(prevSourceId);
+  const changeMainSource = async (newMainSourceId: string) => {
+    if (mainSourceId) {
+      reprojectFromMainStream(mainSourceId);
     }
 
-    projectToMainStream(sourceId).then(() => {
-      setMainSourceId(sourceId);
+    projectToMainStream(newMainSourceId).then(() => {
+      setMainSourceId(newMainSourceId);
       // Reset quality
-      setSourceQuality(sourceId, { streamQuality: 'Auto' });
+      setSourceQuality(newMainSourceId, { streamQuality: 'Auto' });
     });
   };
 
-  const mainSourceSettings = useCallback(() => {
-    if (!mainSource) {
+  const mainSourceSettings = useMemo(() => {
+    if (!mainSourceId) {
       return {};
     }
 
-    const { quality, sourceId, streamQualityOptions } = mainSource;
+    const { quality } = remoteTrackSources.get(mainSourceId) ?? {};
 
     return {
       quality: {
         handleSelect: (data: unknown) => {
-          setSourceQuality(sourceId, data as SimulcastQuality);
+          setSourceQuality(mainSourceId, data as SimulcastQuality);
         },
-        options: streamQualityOptions,
+        options: mainQualityOptions,
         value: quality ?? '',
       },
     };
-  }, [mainSource]);
+  }, [mainQualityOptions, mainSourceId]);
 
   const hasMultiStream = remoteTrackSources.size > 1;
   const isStreaming = remoteTrackSources.size > 0;
@@ -158,7 +155,7 @@ const App = () => {
             <Box height="100%" maxWidth="90vw" test-id="rtsVideoMain" width="80vw">
               <ViewerVideoView
                 isStreaming={isStreaming}
-                settings={mainSourceSettings()}
+                settings={mainSourceSettings}
                 showControlBar
                 statistics={mainStatistics}
                 videoProps={{

--- a/libs/use-viewer/src/index.ts
+++ b/libs/use-viewer/src/index.ts
@@ -19,7 +19,7 @@ import {
   ViewerActionType,
   ViewerProps,
 } from './types';
-import { addRemoteTrack, unprojectFromStream, projectToStream } from './utils';
+import { addRemoteTrack, buildQualityOptions, projectToStream, unprojectFromStream } from './utils';
 
 const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }: ViewerProps): Viewer => {
   const viewerRef = useRef<View>();
@@ -35,6 +35,7 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
   const mainVideoMappingRef = useRef<ViewProjectSourceMapping>();
 
   const [mainMediaStream, setMainMediaStream] = useState<MediaStream>();
+  const [mainQualityOptions, setMainQualityOptions] = useState<SimulcastQuality[]>([]);
   const [mainStatistics, setMainStatistics] = useState<StreamStats>();
   const [viewerCount, setViewerCount] = useState<number>(0);
 
@@ -124,6 +125,15 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
         break;
 
       case 'layers': {
+        const { mediaId } = mainVideoMappingRef.current ?? {};
+
+        if (mediaId) {
+          const mid = parseInt(mediaId, 10);
+          const { active } = (event.data as MediaStreamLayers).medias[mid];
+
+          setMainQualityOptions(buildQualityOptions(active));
+        }
+
         dispatch({
           medias: (event.data as MediaStreamLayers).medias,
           type: ViewerActionType.UPDATE_SOURCES_QUALITY_OPTIONS,
@@ -280,6 +290,7 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
 
   return {
     mainMediaStream,
+    mainQualityOptions,
     mainStatistics,
     projectToMainStream,
     remoteTrackSources,

--- a/libs/use-viewer/src/reducer.ts
+++ b/libs/use-viewer/src/reducer.ts
@@ -1,5 +1,4 @@
 import { RemoteTrackSources, ViewerAction, ViewerActionType } from './types';
-import { buildQualityOptions } from './utils';
 
 const reducer = (state: RemoteTrackSources, action: ViewerAction): RemoteTrackSources => {
   switch (action.type) {
@@ -27,26 +26,6 @@ const reducer = (state: RemoteTrackSources, action: ViewerAction): RemoteTrackSo
       if (prevRemoteTrackSource) {
         newState.set(sourceId, { ...prevRemoteTrackSource, quality });
       }
-
-      return newState;
-    }
-
-    case ViewerActionType.UPDATE_SOURCES_QUALITY_OPTIONS: {
-      const newState = new Map(state);
-
-      Object.entries(action.medias).forEach(([mid, { active }]) => {
-        const [sourceId, remoteTrackSource] =
-          Array.from(state).find(([, { videoMediaId }]) => videoMediaId === mid) ?? [];
-
-        if (sourceId && remoteTrackSource) {
-          const newRemoteTrackSource = {
-            ...remoteTrackSource,
-            streamQualityOptions: buildQualityOptions(active),
-          };
-
-          newState.set(sourceId, newRemoteTrackSource);
-        }
-      });
 
       return newState;
     }

--- a/libs/use-viewer/src/types.ts
+++ b/libs/use-viewer/src/types.ts
@@ -1,10 +1,9 @@
-import { LayerInfo, Media, StreamStats, ViewProjectSourceMapping } from '@millicast/sdk';
+import { LayerInfo, StreamStats, ViewProjectSourceMapping } from '@millicast/sdk';
 
 export enum ViewerActionType {
   ADD_SOURCE = 'ADD_SOURCE',
   REMOVE_SOURCE = 'REMOVE_SOURCE',
   UPDATE_SOURCE_QUALITY = 'UPDATE_SOURCE_QUALITY',
-  UPDATE_SOURCES_QUALITY_OPTIONS = 'UPDATE_SOURCES_QUALITY_OPTIONS',
 }
 
 export interface RemoteTrackSource {
@@ -13,7 +12,6 @@ export interface RemoteTrackSource {
   projectMapping: ViewProjectSourceMapping[];
   quality?: StreamQuality;
   sourceId: string;
-  streamQualityOptions: SimulcastQuality[];
   videoMediaId?: string;
 }
 
@@ -28,6 +26,7 @@ export type StreamQuality = 'Auto' | 'High' | 'Medium' | 'Low';
 
 export interface Viewer {
   mainMediaStream?: MediaStream;
+  mainQualityOptions: SimulcastQuality[];
   mainStatistics?: StreamStats;
   projectToMainStream: (sourceId: string) => Promise<RemoteTrackSource | void>;
   remoteTrackSources: RemoteTrackSources;
@@ -45,8 +44,7 @@ export type ViewerAction =
       type: ViewerActionType.ADD_SOURCE;
     }
   | { sourceId: string; type: ViewerActionType.REMOVE_SOURCE }
-  | { quality: StreamQuality; sourceId: string; type: ViewerActionType.UPDATE_SOURCE_QUALITY }
-  | { medias: Media[]; type: ViewerActionType.UPDATE_SOURCES_QUALITY_OPTIONS };
+  | { quality: StreamQuality; sourceId: string; type: ViewerActionType.UPDATE_SOURCE_QUALITY };
 
 export interface ViewerProps {
   handleError?: (error: string) => void;

--- a/libs/use-viewer/src/utils.ts
+++ b/libs/use-viewer/src/utils.ts
@@ -38,7 +38,6 @@ export const addRemoteTrack = async (
     projectMapping: mapping,
     quality: 'Auto',
     sourceId,
-    streamQualityOptions: [{ streamQuality: 'Auto' }],
     videoMediaId,
   };
 };


### PR DESCRIPTION
#328

The solution to this issue is to:

- [x] Handle quality options for the main stream only. Quality options for the other streams are redundant as they are unused.
- [x] Update dependencies so that the memoised values are updated correctly when quality options change.