### PR TITLE
Issue 314 handle empty audio tracks

### DIFF
--- a/libs/use-viewer/src/utils.ts
+++ b/libs/use-viewer/src/utils.ts
@@ -91,17 +91,15 @@ export const projectToStream = async (
   audioMapping?: ViewProjectSourceMapping,
   videoMapping?: ViewProjectSourceMapping
 ) => {
-  const { audioMediaId, sourceId, videoMediaId } = source;
-
   const mapping: ViewProjectSourceMapping[] = [];
 
-  if (audioMediaId && audioMapping) {
+  if (audioMapping) {
     mapping.push(audioMapping);
   }
 
-  if (videoMediaId && videoMapping) {
+  if (videoMapping) {
     mapping.push(videoMapping);
   }
 
-  await viewer.project(sourceId, mapping);
+  await viewer.project(source.sourceId, mapping);
 };


### PR DESCRIPTION
#314

If the video you are projecting does not have an audio track, it would continue to play the previously projected video's audio. This was solved by providing audio mapping regardless of whether there is or isn't an audio track