### PR TITLE
Issue 301 control bar tweaks in publisher and viewer

### DIFF
--- a/apps/e2e-test/features/publisher-screen-preview.feature
+++ b/apps/e2e-test/features/publisher-screen-preview.feature
@@ -109,7 +109,7 @@ Feature: Publisher Screen Preview
 
         When the publisher hovers the mouse over the "screen view video button"
         Then the "tooltip" should be displayed
-        And the "tooltip" text should be "Toggle camera"
+        And the "tooltip" text should be "Toggle video"
 
         When the publisher hovers the mouse over the "screen view audio button"
         Then the "tooltip" should be displayed

--- a/apps/publisher/src/components/publisher-video-view/video-control-bar/index.tsx
+++ b/apps/publisher/src/components/publisher-video-view/video-control-bar/index.tsx
@@ -51,7 +51,7 @@ const VideoControlBar = ({
       <IconSoundOff />
     );
 
-  const videoLabel = streamType === StreamTypes.MEDIA ? 'Toggle camera' : 'Toggle video';
+  const toggleVideoTooltip = streamType === StreamTypes.MEDIA ? 'Toggle camera' : 'Toggle video';
 
   return (
     <HStack
@@ -91,7 +91,7 @@ const VideoControlBar = ({
             isActive={!activeVideo}
             onClick={handleToggleVideo}
             testId="toggleVideoButton"
-            tooltipProps={{ label: videoLabel, placement: 'bottom' }}
+            tooltipProps={{ label: toggleVideoTooltip, placement: 'bottom' }}
           />
         ) : undefined}
         {canTogglePlayback ? (

--- a/apps/publisher/src/components/publisher-video-view/video-control-bar/index.tsx
+++ b/apps/publisher/src/components/publisher-video-view/video-control-bar/index.tsx
@@ -51,6 +51,8 @@ const VideoControlBar = ({
       <IconSoundOff />
     );
 
+  const videoLabel = streamType === StreamTypes.MEDIA ? 'Toggle camera' : 'Toggle video';
+
   return (
     <HStack
       background="backgroundTranslucent"
@@ -89,7 +91,7 @@ const VideoControlBar = ({
             isActive={!activeVideo}
             onClick={handleToggleVideo}
             testId="toggleVideoButton"
-            tooltipProps={{ label: 'Toggle camera', placement: 'bottom' }}
+            tooltipProps={{ label: videoLabel, placement: 'bottom' }}
           />
         ) : undefined}
         {canTogglePlayback ? (

--- a/apps/publisher/src/components/publisher-video-view/video-control-bar/settings-popover/index.tsx
+++ b/apps/publisher/src/components/publisher-video-view/video-control-bar/settings-popover/index.tsx
@@ -11,7 +11,13 @@ import { SettingsPopoverProps } from './types';
 import { bitrateElementResolver, codecElementResolver, resolutionElementResolver } from './utils';
 
 const SettingsPopover = ({ bitrate, codec, iconProps, name, resolution, simulcast }: SettingsPopoverProps = {}) => (
-  <Popover heading="Stream settings" icon={<IconSettings fill="white" />} iconProps={iconProps} label="Stream settings">
+  <Popover
+    heading="Stream settings"
+    icon={<IconSettings fill="white" />}
+    iconProps={iconProps}
+    label="Stream settings"
+    placement="top-end"
+  >
     {name && !name.isHidden ? (
       <Box>
         <Input

--- a/apps/viewer/src/components/viewer-video-view/index.tsx
+++ b/apps/viewer/src/components/viewer-video-view/index.tsx
@@ -77,7 +77,7 @@ const ViewerVideoView = ({
   const handleChangeVolume = (newVolume: number) => {
     if (newVolume === 0 && audioEnabled) {
       onToggleAudio?.(false);
-    } else if (newVolume > 0 && !audioEnabled) {
+    } else if (!audioEnabled && newVolume > 0) {
       onToggleAudio?.(true);
     }
 

--- a/apps/viewer/src/components/viewer-video-view/index.tsx
+++ b/apps/viewer/src/components/viewer-video-view/index.tsx
@@ -75,11 +75,9 @@ const ViewerVideoView = ({
   };
 
   const handleChangeVolume = (newVolume: number) => {
-    if (newVolume === 0) {
-      audioTrack.enabled = false;
-
+    if (newVolume === 0 && audioEnabled) {
       onToggleAudio?.(false);
-    } else {
+    } else if (newVolume > 0 && !audioEnabled) {
       onToggleAudio?.(true);
     }
 
@@ -87,7 +85,11 @@ const ViewerVideoView = ({
   };
 
   const handleToggleAudio = () => {
-    onToggleAudio?.((prevIsAudioEnabled) => !prevIsAudioEnabled);
+    if (audioEnabled) {
+      handleChangeVolume(0);
+    } else {
+      handleChangeVolume(0.5);
+    }
   };
 
   const handleTogglePlayback = () => {
@@ -128,6 +130,7 @@ const ViewerVideoView = ({
           activeVideo={videoEnabled}
           hasAudioTrack={!!audioTrack}
           hasVideoTrack={!!videoTrack}
+          isFullScreen={fullScreen}
           isStreaming={isStreaming}
           onChangeVolume={handleChangeVolume}
           onToggleAudio={handleToggleAudio}

--- a/apps/viewer/src/components/viewer-video-view/video-control-bar/index.tsx
+++ b/apps/viewer/src/components/viewer-video-view/video-control-bar/index.tsx
@@ -4,7 +4,8 @@ import React from 'react';
 import {
   IconCameraOff,
   IconCameraOn,
-  IconExpand,
+  IconFullScreen,
+  IconFullScreenExit,
   IconPause,
   IconPlay,
   IconSoundOn,
@@ -13,8 +14,8 @@ import {
 import IconButton from '@millicast-react/icon-button';
 import StatisticsPopover from '@millicast-react/statistics-popover';
 
-import { VideoControlBarProps } from './types';
 import SettingsPopover from './settings-popover';
+import { VideoControlBarProps } from './types';
 
 const VideoControlBar = ({
   activeAudio,
@@ -22,6 +23,7 @@ const VideoControlBar = ({
   activeVideo,
   hasAudioTrack,
   hasVideoTrack,
+  isFullScreen,
   isStreaming,
   onChangeVolume: handleChangeVolume,
   onToggleFullScreen: handleFullScreen,
@@ -56,7 +58,7 @@ const VideoControlBar = ({
       </HStack>
       <HStack>
         {hasAudioTrack ? (
-          <Box position="relative">
+          <Box position="relative" sx={{ ':hover>.volume-slider-wrapper': { opacity: 1, visibility: 'visible' } }}>
             <IconButton
               icon={activeAudio ? <IconSoundOn /> : <IconSoundOff />}
               isActive={!activeAudio}
@@ -64,33 +66,37 @@ const VideoControlBar = ({
               testId="toggleAudioButton"
               tooltipProps={{ label: 'Toggle audio', placement: 'bottom' }}
             />
-            <Center
-              background="white"
-              borderRadius="4px"
+            <Box
+              className="volume-slider-wrapper"
               left="50%"
-              padding="12px 0"
+              opacity={0}
               position="absolute"
-              top="-16px"
+              sx={{ ':hover': { opacity: 1, visibility: 'visible' } }}
+              top={0}
               transform="translate(-50%, -100%)"
+              transition="visibility linear 0.5s, opacity 0.5s"
+              visibility="hidden"
               width="100%"
             >
-              <Slider
-                aria-label="volumeSlider"
-                defaultValue={activeAudio ? 100 : 0}
-                height="100px"
-                max={1}
-                min={0}
-                onChange={handleChangeVolume}
-                orientation="vertical"
-                step={0.01}
-                value={volume}
-              >
-                <SliderTrack background="dolbyNeutral.300">
-                  <SliderFilledTrack background="dolbyPurple.400" />
-                </SliderTrack>
-                <SliderThumb background="dolbyNeutral.800" />
-              </Slider>
-            </Center>
+              <Center background="white" borderRadius="4px" marginBottom="16px" padding="12px 0" width="100%">
+                <Slider
+                  aria-label="volumeSlider"
+                  defaultValue={activeAudio ? 100 : 0}
+                  height="100px"
+                  max={1}
+                  min={0}
+                  onChange={handleChangeVolume}
+                  orientation="vertical"
+                  step={0.01}
+                  value={volume}
+                >
+                  <SliderTrack background="dolbyNeutral.300">
+                    <SliderFilledTrack background="dolbyPurple.400" />
+                  </SliderTrack>
+                  <SliderThumb background="dolbyNeutral.800" />
+                </Slider>
+              </Center>
+            </Box>
           </Box>
         ) : undefined}
         {hasVideoTrack ? (
@@ -99,7 +105,7 @@ const VideoControlBar = ({
             isActive={!activeVideo}
             onClick={handleToggleVideo}
             testId="toggleVideoButton"
-            tooltipProps={{ label: 'Toggle camera', placement: 'bottom' }}
+            tooltipProps={{ label: 'Toggle video', placement: 'bottom' }}
           />
         ) : undefined}
         <IconButton
@@ -114,7 +120,7 @@ const VideoControlBar = ({
       <HStack>
         <IconButton
           background="none"
-          icon={<IconExpand fill="white" />}
+          icon={isFullScreen ? <IconFullScreenExit fill="white" /> : <IconFullScreen fill="white" />}
           isDisabled={!hasAudioTrack && !hasVideoTrack}
           onClick={handleFullScreen}
           testId="toggleFullScreenButton"

--- a/apps/viewer/src/components/viewer-video-view/video-control-bar/settings-popover/index.tsx
+++ b/apps/viewer/src/components/viewer-video-view/video-control-bar/settings-popover/index.tsx
@@ -9,7 +9,13 @@ import { SettingsPopoverProps } from './types';
 import { qualityElementResolver } from './utils';
 
 const SettingsPopover = ({ iconProps, quality }: SettingsPopoverProps = {}) => (
-  <Popover heading="Stream settings" icon={<IconSettings fill="white" />} iconProps={iconProps} label="Stream settings">
+  <Popover
+    heading="Stream settings"
+    icon={<IconSettings fill="white" />}
+    iconProps={iconProps}
+    label="Stream settings"
+    placement="top-end"
+  >
     {quality && !quality.isHidden ? (
       <Box>
         <Dropdown

--- a/apps/viewer/src/components/viewer-video-view/video-control-bar/types.ts
+++ b/apps/viewer/src/components/viewer-video-view/video-control-bar/types.ts
@@ -9,6 +9,7 @@ export interface VideoControlBarProps extends StackProps {
   activeVideo?: boolean;
   hasAudioTrack?: boolean;
   hasVideoTrack?: boolean;
+  isFullScreen?: boolean;
   isStreaming?: boolean;
   onChangeVolume?: (volume: number) => void;
   onToggleAudio?: () => void;

--- a/libs/popover/src/index.tsx
+++ b/libs/popover/src/index.tsx
@@ -13,14 +13,14 @@ import IconButton from '@millicast-react/icon-button';
 
 import { PopoverProps } from './types';
 
-const Popover = ({ children, heading, icon, iconProps, label }: PopoverProps) => {
+const Popover = ({ children, heading, icon, iconProps, label, placement }: PopoverProps) => {
   const camelCaseLabel = label
     .replace(/^./, (firstChar) => firstChar.toLowerCase())
     .replace(/\s+(\w)/, (_, char) => char.toUpperCase());
 
   return (
     <>
-      <ChakraPopover isLazy placement="top-start">
+      <ChakraPopover isLazy placement={placement}>
         <PopoverTrigger>
           <IconButton
             aria-label={label}

--- a/libs/popover/src/types.ts
+++ b/libs/popover/src/types.ts
@@ -1,4 +1,4 @@
-import { IconButtonProps } from '@chakra-ui/react';
+import { IconButtonProps, PlacementWithLogical } from '@chakra-ui/react';
 import { PropsWithChildren, ReactElement } from 'react';
 
 export type PopoverProps = PropsWithChildren<{
@@ -6,4 +6,5 @@ export type PopoverProps = PropsWithChildren<{
   icon: ReactElement;
   iconProps?: Omit<IconButtonProps, 'aria-label'>;
   label: string;
+  placement?: PlacementWithLogical;
 }>;

--- a/libs/statistics-popover/src/index.tsx
+++ b/libs/statistics-popover/src/index.tsx
@@ -50,6 +50,7 @@ const StatisticsPopover = ({ iconProps, statistics }: StatisticsPopoverProps) =>
       icon={<IconInfo fill="white" />}
       iconProps={iconProps}
       label="Stream information"
+      placement="top-start"
     >
       {statistics ? (
         tabs.length ? (


### PR DESCRIPTION
#301 

- [x] Change the tooltip:
  - [x] [Publisher App] For screen share and local file stream: Change the tooltip from Toggle camera -> Toggle Video
  - [x] [Viewer App] For different streams: Change the tooltip from Toggle camera -> Toggle Video
- [x] [Viewer App] On the viewer app when the audio is unmuted from the video view, volume slider should be set to 50% instead of 0%
- [x] [Viewer App] volume slider should be hidden after the volume is set/changed
- [x] [Viewer App] After the viewer toggle to full screen, the icon should change to shrink screen but it still shows full screen icon
- [x] [Publisher & Viewer App] Flip the settings popover so it points to the left