### PR TITLE
Issue 296 screen share stream in viewer stuck on loading

### DIFF
--- a/apps/viewer/src/components/content.tsx
+++ b/apps/viewer/src/components/content.tsx
@@ -309,7 +309,7 @@ const Content = () => {
                             mediaStream={source.mediaStream}
                             volume={attributes?.volume}
                             displayVideo={attributes?.displayVideo}
-                            muted={attributes?.volume === 0}
+                            muted={attributes?.muteAudio || attributes?.volume === 0}
                             displayMuteButton={true}
                           />
                           <ControlBar


### PR DESCRIPTION
#296

The `video` element for screenshare streams in Viewer was receiving the incorrect value for `mute`, which meant the initial value was `false`. Autoplay with sound will not always work, causing the bug.