### PR TITLE
Issue 323 can not stream local file in safari

### DIFF
--- a/apps/publisher/src/app.tsx
+++ b/apps/publisher/src/app.tsx
@@ -453,11 +453,16 @@ const App = () => {
                 onClick: handleOpenDeviceSelection,
                 text: 'Add cameras',
               },
-              {
-                icon: <IconStreamLocal />,
-                onClick: onFileSelectModalOpen,
-                text: 'Stream local file',
-              },
+              ...('captureStream' in HTMLMediaElement
+                ? [
+                    {
+                      icon: <IconStreamLocal />,
+                      isDisabled: !('captureStream' in HTMLMediaElement),
+                      onClick: onFileSelectModalOpen,
+                      text: 'Stream local file',
+                    },
+                  ]
+                : []),
             ]}
           />
           <DeviceSelection

--- a/apps/publisher/src/app.tsx
+++ b/apps/publisher/src/app.tsx
@@ -453,6 +453,8 @@ const App = () => {
                 onClick: handleOpenDeviceSelection,
                 text: 'Add cameras',
               },
+              // It is not possible to stream local files if HTMLMediaElement.captureStream is not available
+              // e.g. on Safari https://caniuse.com/?search=captureStream
               ...('captureStream' in HTMLMediaElement
                 ? [
                     {


### PR DESCRIPTION
#323 
Disabled local file streaming if `HTMLMediaElement.captureStream` is not available