### PR TITLE
Issue 360 handle empty source name in dolby.io broadcast app

### DIFF
--- a/apps/e2e-test/src/reporter/cucumber-report.ts
+++ b/apps/e2e-test/src/reporter/cucumber-report.ts
@@ -18,7 +18,7 @@ const reportOptions: Options = {
   scenarioTimestamp: true,
   launchReport: false,
   metadata: {
-    'App Version': '2.0.0',
+    'App Version': '2.0.1',
     'Test Environment': 'DEV',
     Browser: `${browserMgr.options.browserName}`,
     Headless: `${browserMgr.options.headless}`,

--- a/apps/e2e-test/src/steps/app-specific/workflow/workflow.data.ts
+++ b/apps/e2e-test/src/steps/app-specific/workflow/workflow.data.ts
@@ -142,7 +142,7 @@ const publisherPreviewFooterData: ViewData = {
   'add source button': 'displayed|enabled',
   'add source button text': 'Add Source',
   'app version': 'displayed',
-  'app version text': 'Version: 2.0.0',
+  'app version text': 'Version: 2.0.1',
 };
 
 const publisherStreamingFooterData: ViewData = publisherPreviewFooterData;
@@ -150,7 +150,7 @@ const publisherStreamingFooterData: ViewData = publisherPreviewFooterData;
 const viewerWaitingRoomFooterData: ViewData = {
   'add source button': 'hidden',
   'app version': 'displayed',
-  'app version text': 'Version: 2.0.0',
+  'app version text': 'Version: 2.0.1',
 };
 
 const viewerStreamingFooterData: ViewData = viewerWaitingRoomFooterData;

--- a/apps/publisher/vite.config.ts
+++ b/apps/publisher/vite.config.ts
@@ -6,7 +6,7 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 export default defineConfig({
   plugins: [tsconfigPaths(), react(), eslint()],
   define: {
-    __APP_VERSION__: JSON.stringify('2.0.0'),
+    __APP_VERSION__: JSON.stringify('2.0.1'),
   },
   preview: {
     open: false,

--- a/apps/viewer/src/app.tsx
+++ b/apps/viewer/src/app.tsx
@@ -39,7 +39,7 @@ const App = () => {
 
   const viewerPlaybackControl = usePlaybackControl(Array.from(remoteTrackSources).map(([sourceId]) => sourceId));
 
-  const [mainSourceId, setMainSourceId] = useState<string>();
+  const [mainSourceId, setMainSourceId] = useState<string | null>();
 
   // Prevent closing the page
   useEffect(() => {
@@ -63,7 +63,7 @@ const App = () => {
 
   // Assign the first source as the initial main stream
   useEffect(() => {
-    if (remoteTrackSources.size && (!mainSourceId || !remoteTrackSources.get(mainSourceId))) {
+    if (remoteTrackSources.size && (mainSourceId === undefined || !remoteTrackSources.get(mainSourceId))) {
       const [[firstSourceId]] = remoteTrackSources;
 
       setMainSourceId(firstSourceId);
@@ -73,14 +73,15 @@ const App = () => {
 
   // Reset main stream when layers change
   useEffect(() => {
-    if (!mainSourceId) {
+    if (mainSourceId === undefined) {
       return;
     }
+
     setSourceQuality(mainSourceId);
   }, [mainQualityOptions.length]);
 
   const changeMainSource = async (newMainSourceId: string) => {
-    if (mainSourceId) {
+    if (mainSourceId !== undefined) {
       reprojectFromMainStream(mainSourceId);
     }
 
@@ -92,7 +93,7 @@ const App = () => {
   };
 
   const mainSourceSettings = useMemo(() => {
-    if (!mainSourceId) {
+    if (mainSourceId === undefined) {
       return {};
     }
 
@@ -137,7 +138,7 @@ const App = () => {
         </Flex>
       </Box>
       <Flex alignItems="center" flex={1} justifyContent="center" width="100%">
-        {!isStreaming || !mainSourceId ? (
+        {!isStreaming || mainSourceId === undefined ? (
           <VStack>
             <Heading as="h2" fontSize="24px" fontWeight="600" test-id="pageHeader">
               Stream is not live

--- a/apps/viewer/src/app.tsx
+++ b/apps/viewer/src/app.tsx
@@ -39,7 +39,7 @@ const App = () => {
 
   const viewerPlaybackControl = usePlaybackControl(Array.from(remoteTrackSources).map(([sourceId]) => sourceId));
 
-  const [mainSourceId, setMainSourceId] = useState<string | null>();
+  const [mainSourceId, setMainSourceId] = useState('');
 
   // Prevent closing the page
   useEffect(() => {
@@ -63,7 +63,7 @@ const App = () => {
 
   // Assign the first source as the initial main stream
   useEffect(() => {
-    if (remoteTrackSources.size && (mainSourceId === undefined || !remoteTrackSources.get(mainSourceId))) {
+    if (remoteTrackSources.size && (mainSourceId === '' || !remoteTrackSources.get(mainSourceId))) {
       const [[firstSourceId]] = remoteTrackSources;
 
       setMainSourceId(firstSourceId);
@@ -73,7 +73,7 @@ const App = () => {
 
   // Reset main stream when layers change
   useEffect(() => {
-    if (mainSourceId === undefined) {
+    if (mainSourceId === '') {
       return;
     }
 
@@ -81,7 +81,7 @@ const App = () => {
   }, [mainQualityOptions.length]);
 
   const changeMainSource = async (newMainSourceId: string) => {
-    if (mainSourceId !== undefined) {
+    if (mainSourceId !== '') {
       reprojectFromMainStream(mainSourceId);
     }
 
@@ -93,7 +93,7 @@ const App = () => {
   };
 
   const mainSourceSettings = useMemo(() => {
-    if (mainSourceId === undefined) {
+    if (mainSourceId === '') {
       return {};
     }
 
@@ -138,7 +138,7 @@ const App = () => {
         </Flex>
       </Box>
       <Flex alignItems="center" flex={1} justifyContent="center" width="100%">
-        {!isStreaming || mainSourceId === undefined ? (
+        {!isStreaming || mainSourceId === '' ? (
           <VStack>
             <Heading as="h2" fontSize="24px" fontWeight="600" test-id="pageHeader">
               Stream is not live

--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -6,7 +6,7 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 export default defineConfig({
   plugins: [tsconfigPaths(), react(), eslint()],
   define: {
-    __APP_VERSION__: JSON.stringify('2.0.0'),
+    __APP_VERSION__: JSON.stringify('2.0.1'),
   },
   preview: {
     open: false,

--- a/libs/use-viewer/src/index.ts
+++ b/libs/use-viewer/src/index.ts
@@ -72,6 +72,8 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
       return;
     }
 
+    // Due to CAPI platform limitations, only one source can be unnamed
+    // We can only handle one unnamed source here
     const { sourceId = null, tracks } = event.data as MediaStreamSource;
 
     switch (event.name) {

--- a/libs/use-viewer/src/index.ts
+++ b/libs/use-viewer/src/index.ts
@@ -225,7 +225,7 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
 
     if (remoteTrackSource) {
       try {
-        await viewer.project(sourceId ?? undefined, remoteTrackSource.projectMapping);
+        await viewer.project(sourceId, remoteTrackSource.projectMapping);
       } catch (error) {
         handleInternalError(error);
       }

--- a/libs/use-viewer/src/index.ts
+++ b/libs/use-viewer/src/index.ts
@@ -72,8 +72,12 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
       return;
     }
 
-    // Due to CAPI platform limitations, only one source can be unnamed
-    // We can only handle one unnamed source here
+    // Due to CAPI platform limitations, only one source can be unnamed (where sourceId is undefined)
+    // By default, the single unnamed source would be treated as the main source
+    // If there are multiple unnamed sources, we can not distinguish which events belong to which sources
+    // Although this is a known unclosed edge case:
+    // In Publisher app, validation is enforced to ensure all sources have a name
+    // In current dolby.io dashboard broadcast app, only one source can be published at a time
     const { sourceId, tracks } = event.data as MediaStreamSource;
 
     switch (event.name) {

--- a/libs/use-viewer/src/index.ts
+++ b/libs/use-viewer/src/index.ts
@@ -72,7 +72,7 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
       return;
     }
 
-    const { sourceId, tracks } = event.data as MediaStreamSource;
+    const { sourceId = null, tracks } = event.data as MediaStreamSource;
 
     switch (event.name) {
       case 'active':
@@ -93,7 +93,7 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
               mainVideoMappingRef.current
             );
           } else {
-            await viewer.project(sourceId, newRemoteTrackSource.projectMapping);
+            await viewer.project(sourceId ?? undefined, newRemoteTrackSource.projectMapping);
           }
         } catch (error) {
           handleInternalError(error);
@@ -191,7 +191,7 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
     }
   };
 
-  const projectToMainStream = async (sourceId: string): Promise<RemoteTrackSource | void> => {
+  const projectToMainStream = async (sourceId: string | null): Promise<RemoteTrackSource | void> => {
     const { current: viewer } = viewerRef;
 
     if (!viewer) {
@@ -212,7 +212,7 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
     }
   };
 
-  const reprojectFromMainStream = async (sourceId: string) => {
+  const reprojectFromMainStream = async (sourceId: string | null) => {
     const { current: viewer } = viewerRef;
 
     if (!viewer) {
@@ -223,14 +223,14 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
 
     if (remoteTrackSource) {
       try {
-        await viewer.project(sourceId, remoteTrackSource.projectMapping);
+        await viewer.project(sourceId ?? undefined, remoteTrackSource.projectMapping);
       } catch (error) {
         handleInternalError(error);
       }
     }
   };
 
-  const setSourceQuality = (sourceId: string, quality?: SimulcastQuality) => {
+  const setSourceQuality = (sourceId: string | null, quality?: SimulcastQuality) => {
     const { current: viewer } = viewerRef;
 
     if (!viewer) {

--- a/libs/use-viewer/src/index.ts
+++ b/libs/use-viewer/src/index.ts
@@ -74,7 +74,7 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
 
     // Due to CAPI platform limitations, only one source can be unnamed
     // We can only handle one unnamed source here
-    const { sourceId = null, tracks } = event.data as MediaStreamSource;
+    const { sourceId, tracks } = event.data as MediaStreamSource;
 
     switch (event.name) {
       case 'active':
@@ -95,7 +95,7 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
               mainVideoMappingRef.current
             );
           } else {
-            await viewer.project(sourceId ?? undefined, newRemoteTrackSource.projectMapping);
+            await viewer.project(sourceId, newRemoteTrackSource.projectMapping);
           }
         } catch (error) {
           handleInternalError(error);
@@ -193,7 +193,7 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
     }
   };
 
-  const projectToMainStream = async (sourceId: string | null): Promise<RemoteTrackSource | void> => {
+  const projectToMainStream = async (sourceId?: string): Promise<RemoteTrackSource | void> => {
     const { current: viewer } = viewerRef;
 
     if (!viewer) {
@@ -214,7 +214,7 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
     }
   };
 
-  const reprojectFromMainStream = async (sourceId: string | null) => {
+  const reprojectFromMainStream = async (sourceId?: string) => {
     const { current: viewer } = viewerRef;
 
     if (!viewer) {
@@ -232,7 +232,7 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
     }
   };
 
-  const setSourceQuality = (sourceId: string | null, quality?: SimulcastQuality) => {
+  const setSourceQuality = (sourceId?: string, quality?: SimulcastQuality) => {
     const { current: viewer } = viewerRef;
 
     if (!viewer) {

--- a/libs/use-viewer/src/types.ts
+++ b/libs/use-viewer/src/types.ts
@@ -11,7 +11,7 @@ export interface RemoteTrackSource {
   mediaStream: MediaStream;
   projectMapping: ViewProjectSourceMapping[];
   quality?: StreamQuality;
-  sourceId: string | null;
+  sourceId?: string;
   videoMediaId?: string;
 }
 
@@ -28,10 +28,10 @@ export interface Viewer {
   mainMediaStream?: MediaStream;
   mainQualityOptions: SimulcastQuality[];
   mainStatistics?: StreamStats;
-  projectToMainStream: (sourceId: string | null) => Promise<RemoteTrackSource | void>;
+  projectToMainStream: (sourceId?: string) => Promise<RemoteTrackSource | void>;
   remoteTrackSources: RemoteTrackSources;
-  reprojectFromMainStream: (sourceId: string | null) => void;
-  setSourceQuality: (sourceId: string | null, quality?: SimulcastQuality) => void;
+  reprojectFromMainStream: (sourceId?: string) => void;
+  setSourceQuality: (sourceId?: string, quality?: SimulcastQuality) => void;
   startViewer: () => void;
   stopViewer: () => void;
   viewerCount: number;
@@ -40,11 +40,11 @@ export interface Viewer {
 export type ViewerAction =
   | {
       remoteTrackSource: RemoteTrackSource;
-      sourceId: string | null;
+      sourceId?: string;
       type: ViewerActionType.ADD_SOURCE;
     }
-  | { sourceId: string | null; type: ViewerActionType.REMOVE_SOURCE }
-  | { quality: StreamQuality; sourceId: string | null; type: ViewerActionType.UPDATE_SOURCE_QUALITY };
+  | { sourceId?: string; type: ViewerActionType.REMOVE_SOURCE }
+  | { quality: StreamQuality; sourceId?: string; type: ViewerActionType.UPDATE_SOURCE_QUALITY };
 
 export interface ViewerProps {
   handleError?: (error: string) => void;

--- a/libs/use-viewer/src/types.ts
+++ b/libs/use-viewer/src/types.ts
@@ -11,7 +11,7 @@ export interface RemoteTrackSource {
   mediaStream: MediaStream;
   projectMapping: ViewProjectSourceMapping[];
   quality?: StreamQuality;
-  sourceId: string;
+  sourceId: string | null;
   videoMediaId?: string;
 }
 
@@ -28,10 +28,10 @@ export interface Viewer {
   mainMediaStream?: MediaStream;
   mainQualityOptions: SimulcastQuality[];
   mainStatistics?: StreamStats;
-  projectToMainStream: (sourceId: string) => Promise<RemoteTrackSource | void>;
+  projectToMainStream: (sourceId: string | null) => Promise<RemoteTrackSource | void>;
   remoteTrackSources: RemoteTrackSources;
-  reprojectFromMainStream: (sourceId: string) => void;
-  setSourceQuality: (sourceId: string, quality?: SimulcastQuality) => void;
+  reprojectFromMainStream: (sourceId: string | null) => void;
+  setSourceQuality: (sourceId: string | null, quality?: SimulcastQuality) => void;
   startViewer: () => void;
   stopViewer: () => void;
   viewerCount: number;
@@ -40,11 +40,11 @@ export interface Viewer {
 export type ViewerAction =
   | {
       remoteTrackSource: RemoteTrackSource;
-      sourceId: string;
+      sourceId: string | null;
       type: ViewerActionType.ADD_SOURCE;
     }
-  | { sourceId: string; type: ViewerActionType.REMOVE_SOURCE }
-  | { quality: StreamQuality; sourceId: string; type: ViewerActionType.UPDATE_SOURCE_QUALITY };
+  | { sourceId: string | null; type: ViewerActionType.REMOVE_SOURCE }
+  | { quality: StreamQuality; sourceId: string | null; type: ViewerActionType.UPDATE_SOURCE_QUALITY };
 
 export interface ViewerProps {
   handleError?: (error: string) => void;

--- a/libs/use-viewer/src/utils.ts
+++ b/libs/use-viewer/src/utils.ts
@@ -3,7 +3,7 @@ import { RemoteTrackSource, SimulcastQuality, StreamQuality } from './types';
 
 export const addRemoteTrack = async (
   viewer: View,
-  sourceId: string | null,
+  sourceId?: string,
   trackInfo?: MediaTrackInfo[]
 ): Promise<RemoteTrackSource> => {
   const mapping: ViewProjectSourceMapping[] = [];
@@ -100,5 +100,5 @@ export const projectToStream = async (
     mapping.push(videoMapping);
   }
 
-  await viewer.project(source.sourceId ?? undefined, mapping);
+  await viewer.project(source.sourceId, mapping);
 };

--- a/libs/use-viewer/src/utils.ts
+++ b/libs/use-viewer/src/utils.ts
@@ -3,7 +3,7 @@ import { RemoteTrackSource, SimulcastQuality, StreamQuality } from './types';
 
 export const addRemoteTrack = async (
   viewer: View,
-  sourceId: string,
+  sourceId: string | null,
   trackInfo?: MediaTrackInfo[]
 ): Promise<RemoteTrackSource> => {
   const mapping: ViewProjectSourceMapping[] = [];
@@ -100,5 +100,5 @@ export const projectToStream = async (
     mapping.push(videoMapping);
   }
 
-  await viewer.project(source.sourceId, mapping);
+  await viewer.project(source.sourceId ?? undefined, mapping);
 };

--- a/libs/video-view/src/types.ts
+++ b/libs/video-view/src/types.ts
@@ -9,7 +9,7 @@ export interface HTMLVideoElementWithCaptureStream extends HTMLVideoElement {
 export interface VideoViewProps {
   displayVideo?: boolean;
   height?: string;
-  label?: string | null;
+  label?: string;
   mediaStream?: MediaStream;
   mirrored?: boolean;
   muted?: boolean;

--- a/libs/video-view/src/types.ts
+++ b/libs/video-view/src/types.ts
@@ -9,7 +9,7 @@ export interface HTMLVideoElementWithCaptureStream extends HTMLVideoElement {
 export interface VideoViewProps {
   displayVideo?: boolean;
   height?: string;
-  label?: string;
+  label?: string | null;
   mediaStream?: MediaStream;
   mirrored?: boolean;
   muted?: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "millicast-react",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "scripts": {
     "start": "nx serve",


### PR DESCRIPTION
#360 

Current broadcast app in dolby.io dashboard publishes a single stream with no name/label. Because stream labels are used for identification in the Viewer app, there was an edge case where unnamed streams were causing the Viewer to crash.

> Jack Shen
>   2 hours ago
> I've made changes in Viewer to handle  missing source IDs, so that [dolby.io](http://dolby.io/)'s Millicast Publisher should work.
> The problem is if we have more than one stream without a source ID, it's entirely impossible to tell which event belongs to which stream.
> In other words, we can support viewing ONLY one stream with a missing label/source ID
> 
> 
> 
> 
> 
> Jack Shen
>   1 hour ago
> oh it'll also break if there's one unnamed stream and one stream named "null"
> 
> 
> Jack Shen
>   1 hour ago
> In the publisher app, we explicitly disallow unnamed streams. I can commit my changes, but it's very specific to this one issue in [dolby.io](http://dolby.io/) dashboard, and would otherwise be a flawed implementation
> 
> 
> Jack Shen
>   1 hour ago
> [@Vincent Song]()
>  lmk your thoughts on this issue
> 
> 
> Wenfeng Song
>   1 hour ago
> we only take one source without name, when another empty source name comes, we ignore it. Or could we give it a name when it’s empty name?
> 
> 
> Jack Shen
>   1 hour ago
> Right now, in Publisher app, sources must have a name. When every source has a name, there's no problem in Viewer app
> 
> 
> Jack Shen
>   1 hour ago
> The problem is [dolby.io](http://dolby.io/) dashboard app uses a source without a name
> 
> 
> Jack Shen
>   1 hour ago
> My current changes are able to address this edge case, but the [dolby.io](http://dolby.io/) dashboard app should not be publishing streams that are missing names
> 
> 
> Wenfeng Song
>   1 hour ago
> Sure, I got it. The product owner told me they only allow one empty name source. So let’s ignore the coming empty name sources if that happen.
> 
> 
> Jack Shen
>   1 hour ago
> Unfortunately, we can not ignore the coming empty name sources because won't know which one it belongs to (the first one, or the second one)
> 
> 
> Jack Shen
>   1 hour ago
> The good thing is it looks like the [dolby.io](http://dolby.io/) dashboard app can't publish more than one stream at a time
> 
> 
> Jack Shen
>   1 hour ago
> But the bottom line is that the fix is fundamentally flawed
> 
> 
> Wenfeng Song
>   1 hour ago
> I mean if we received the first empty id in active event, then we will not accept any source with an empty id until we received inactive event with an empty source id.
> 
> 
> Jack Shen
>   1 hour ago
> The problem extends further than that, because we'll still receive other events such as layers and we won't know which it belongs to (edited) 
> 
> 
> Jack Shen
>   1 hour ago
> Again, this isn't an immediate problem as it's not possible to have streams with no name in Publisher app or more than one stream with no name in [dolby.io](http://dolby.io/) broadcast app (edited) 
> 
> 
> Wenfeng Song
>   1 hour ago
> yes, let’s assume we only handle one stream with no name.
> 
> 
> Wenfeng Song
>   1 hour ago
> [@shivank.dubey]()
>  do you think we need mention this in README.md?
> 
> 
> Jack Shen
>   1 hour ago
> Ideally, we should roll back the changes I've made once the fundamental problem has been solved in [dolby.io](http://dolby.io/) broadcaster app
> 
> 
> Wenfeng Song
>   1 hour ago
> It should be fine, we only handle one empty name source, it should work even after the broadcast app solved this issue, isn’t it?
> 
> 
> Jack Shen
>   43 minutes ago
> Yes, but the implementation necessarily has other issues:
> - Can't have an empty name source and a source named "null"
> - Edge case with more than one empty name source (we don't anticipate this scenario, but it's still an unclosed edge case)
> - TypeScript isn't happy
> (edited)