### PR TITLE
Missing stream stats for Safari n Firefox

### DIFF
--- a/libs/use-viewer/src/index.ts
+++ b/libs/use-viewer/src/index.ts
@@ -184,6 +184,8 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
     const { audio, video } = statistics.input;
 
     const mainAudio = audio.filter(({ mid }) => mid === mainAudioMIDRef.current) ?? [];
+
+    // Safari and Firefox do not report on mid so we fall back to trackIdentifier to easily pick up stats when streaming with multiple sources
     const mainVideo = video.filter(({ trackIdentifier }) => trackIdentifier === mainVideoTrackIdRef.current);
 
     setMainStatistics({ ...statistics, input: { audio: mainAudio, video: mainVideo } });

--- a/libs/use-viewer/src/index.ts
+++ b/libs/use-viewer/src/index.ts
@@ -2,6 +2,7 @@ import WebRTCStats, { OnStats } from '@dolbyio/webrtc-stats';
 import { BroadcastEvent, Director, MediaStreamLayers, MediaStreamSource, View, ViewerCount } from '@millicast/sdk';
 import { useReducer, useRef } from 'react';
 import useState from 'react-usestateref';
+import { first } from 'lodash';
 
 import reducer from './reducer';
 import {
@@ -37,6 +38,7 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
   const activeEventCounterRef = useRef(0);
   const mainAudioMIDRef = useRef<string>();
   const mainVideoMIDRef = useRef<string>();
+  const mainVideoTrackIdRef = useRef<string>();
   const [mainMediaStream, setMainMediaStream, mainMediaStreamRef] = useState<MediaStream>();
   const [mainSourceId, setMainSourceId, mainSourceIdRef] = useState<string>();
   const [mainQualityOptions, setMainQualityOptions] = useState<SimulcastQuality[]>(buildQualityOptions());
@@ -182,7 +184,7 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
     const { audio, video } = statistics.input;
 
     const mainAudio = audio.filter(({ mid }) => mid === mainAudioMIDRef.current) ?? [];
-    const mainVideo = video.filter(({ mid }) => mid === mainVideoMIDRef.current) ?? [];
+    const mainVideo = video.filter(({ trackIdentifier }) => trackIdentifier === mainVideoTrackIdRef.current);
 
     setMainStatistics({ ...statistics, input: { audio: mainAudio, video: mainVideo } });
   };
@@ -274,6 +276,7 @@ const useViewer = ({ handleError, streamAccountId, streamName, subscriberToken }
       mainAudioMIDRef.current = mid || undefined;
     } else if (kind === 'video') {
       mainVideoMIDRef.current = mid || undefined;
+      mainVideoTrackIdRef.current = first(mediaStream?.getVideoTracks())?.id;
     }
     setMainMediaStream(mediaStream);
   };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@chakra-ui/react": "^2.4.1",
     "@cucumber/cucumber": "^8.7.0",
-    "@dolbyio/webrtc-stats": "^0.2.0",
+    "@dolbyio/webrtc-stats": "^0.3.0",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@millicast/sdk": "^0.1.39",
@@ -25,6 +25,7 @@
     "cucumber-html-reporter": "^5.5.0",
     "framer-motion": "^7",
     "js-yaml": "^4.1.0",
+    "lodash": "^4.17.21",
     "pixelmatch": "^5.3.0",
     "playwright": "^1.31.0",
     "react": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2305,10 +2305,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@dolbyio/webrtc-stats@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@dolbyio/webrtc-stats/-/webrtc-stats-0.2.0.tgz#9749ce4c8063c6273d3e1715bab916d8bc44f785"
-  integrity sha512-dkkKFpAPmmrPun9RPv9vfDGYbkY+ICHMmTjzoDBVq9rI+nyFlfQPxKRY+Rz2lVRbk1Zie+lJ8OdvtK6I3UUaBQ==
+"@dolbyio/webrtc-stats@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@dolbyio/webrtc-stats/-/webrtc-stats-0.3.0.tgz#f48814dbb0c6866d4b63c0bdc48fe9043e5aca28"
+  integrity sha512-1lIvblSCd8za2+TXnc75gxDn5dYFHuYcjb9+wjj/NHDe+bogEJX1+HIJmLEoIHnJJMu8Ee8OQbdhqxADzSLZfA==
   dependencies:
     js-logger "^1.6.1"
 


### PR DESCRIPTION
This PR addresses this bug https://github.com/dolbyio-samples/rts-app-react-publisher-viewer/issues/157

This also has
- added `lodash` dependency, which was already being included by storybooks
- bumped `@dolbyio/webrtc-stats` version to be able to access new added property called `trackIdentifier`